### PR TITLE
[FIX] error message when you create or modify a link

### DIFF
--- a/Classes/RecordList/RecordRecordList.php
+++ b/Classes/RecordList/RecordRecordList.php
@@ -165,7 +165,7 @@ class RecordRecordList extends DatabaseRecordList
 		return $this->addElement(1, '', $data);
 	}
 
-	public function getSearchBox() {
+	public function getSearchBox($formFields = true) {
 
 		$formElements = array('<form action="' . htmlspecialchars($this->getSearchURL()) . '" method="post" style="padding:0;">', '</form>');
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "GPL-2.0",
   "version": "1.2.0",
   "require": {
-    "typo3/cms": ">=7.6.0 <7.6.99"
+    "typo3/cms": ">=7.6.0 <8.7.99"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' => 
 		array (
-			'typo3' => '7.6.0-7.6.99',
+			'typo3' => '7.6.0-8.7.99',
 		),
 		'conflicts' => 
 		array (


### PR DESCRIPTION
PHP Warning

Core: Error handler (BE): PHP Warning: Declaration of Intera\Recordlink\RecordList\RecordRecordList::getSearchBox() should be compatible with TYPO3\CMS\Recordlist\RecordList\AbstractDatabaseRecordList::getSearchBox($formFields = true) in /web/typo3conf/ext/recordlink/Classes/RecordList/RecordRecordList.php line 25