### PR TITLE
Develop

### DIFF
--- a/Classes/Hooks/FormEngineLinkHandler.php
+++ b/Classes/Hooks/FormEngineLinkHandler.php
@@ -1,0 +1,73 @@
+<?php
+namespace Intera\Recordlink\Hooks;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Buja Cristian <cristian.buja@intera.it>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Imaging\Icon;
+
+/**
+ * FormEngine linkHandler Hooks
+ *
+ * @package Recordlink
+ * @subpackage Hooks
+ * @route off
+ */
+class FormEngineLinkHandler {
+
+	/**
+	 * Get Form Data
+	 *
+	 * @param array $linkData
+	 * @param array $linkParts
+	 * @param array $data
+	 * @param AbstractFormElement $pObj
+	 * @return string
+	 */
+    public function getFormData($linkData, $linkParts, $data, $pObj) {
+
+	    $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+
+        $table = $data['pageTsConfig']['TCEMAIN.']['linkHandler.'][$linkData['type'] . '.']['configuration.'][$linkData['identifier'] . '.']['table'];
+        $record = BackendUtility::getRecord($table, $linkData['uid']);
+        $recordTitle = BackendUtility::getRecordTitle($table, $record);
+        $label = $data['pageTsConfig']['TCEMAIN.']['linkHandler.'][$linkData['type'] . '.']['configuration.'][$linkData['identifier'] . '.']['label'];
+
+	    if ($table) {
+		    return [
+			    'text' => sprintf('%s [%s:%d]', $recordTitle, $label, $linkData['uid']),
+			    'icon' => $iconFactory->getIconForRecord($table, $record, Icon::SIZE_SMALL)->render()
+		    ];
+	    } else {
+		    return [
+			    'text' => $linkData['type'] . ' ' . $linkData['identifier'] . ' ' . $linkData['uid'],
+			    'icon' => ''
+		    ];
+	    }
+  }
+
+}

--- a/Classes/Hooks/RecordLinkBuilder.php
+++ b/Classes/Hooks/RecordLinkBuilder.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+namespace Intera\Recordlink\Hooks;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Typolink\DatabaseRecordLinkBuilder;
+use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
+
+
+/**
+ * Builds a TypoLink to a database record
+ */
+class RecordLinkBuilder extends DatabaseRecordLinkBuilder
+{
+    /**
+     * @inheritdoc
+     */
+    public function build(array &$linkDetails, string $linkText, string $target, array $conf): array
+    {
+
+        $tsfe = $this->getTypoScriptFrontendController();
+        $configurationKey = $linkDetails['identifier'] . '.';
+        $configuration = $tsfe->tmpl->setup['plugin.']['tx_recordlink.'];
+        $linkHandlerConfiguration = $tsfe->pagesTSconfig['TCEMAIN.']['linkHandler.']['recordlink.']['configuration.'];
+
+
+        if (!isset($configuration[$configurationKey]) || !isset($linkHandlerConfiguration[$configurationKey])) {
+            throw new UnableToLinkException(
+                'Configuration how to link "' . $linkDetails['typoLinkParameter'] . '" was not found, so "' . $linkText . '" was not linked.',
+                1490989149,
+                null,
+                $linkText
+            );
+        }
+        $typoScriptConfiguration = $configuration[$configurationKey]['typolink.'];
+
+        if ($configuration[$configurationKey]['forceLink']) {
+            $record = $tsfe->sys_page->getRawRecord($linkHandlerConfiguration[$configurationKey]['table'], $linkDetails['uid']);
+        } else {
+            $record = $tsfe->sys_page->checkRecord($linkHandlerConfiguration[$configurationKey]['table'], $linkDetails['uid']);
+        }
+
+        if ($record === 0) {
+            throw new UnableToLinkException(
+                'Record not found for "' . $linkDetails['typoLinkParameter'] . '" was not found, so "' . $linkText . '" was not linked.',
+                1490989659,
+                null,
+                $linkText
+            );
+        }
+
+        // Build the full link to the record
+        $localContentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $localContentObjectRenderer->start($record, $linkHandlerConfiguration['table']);
+        $localContentObjectRenderer->parameters = $this->contentObjectRenderer->parameters;
+        $link = $localContentObjectRenderer->typoLink($linkText, $typoScriptConfiguration);
+
+        $this->contentObjectRenderer->lastTypoLinkLD = $localContentObjectRenderer->lastTypoLinkLD;
+        $this->contentObjectRenderer->lastTypoLinkUrl = $localContentObjectRenderer->lastTypoLinkUrl;
+        $this->contentObjectRenderer->lastTypoLinkTarget = $localContentObjectRenderer->lastTypoLinkTarget;
+
+        // nasty workaround so typolink stops putting a link together, there is a link already built
+        throw new UnableToLinkException(
+            '', 1491130170, null, $link
+        );
+    }
+}

--- a/Classes/LinkHandler/RecordLinkHandler.php
+++ b/Classes/LinkHandler/RecordLinkHandler.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Recordlist\Controller\AbstractLinkBrowserController;
 use TYPO3\CMS\Recordlist\Tree\View\LinkParameterProviderInterface;
 use Intera\Recordlink\RecordList\RecordRecordList;
 
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+
 /**
  * Link handler for record links
  */
@@ -51,6 +53,8 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
     public function initialize(AbstractLinkBrowserController $linkBrowser, $identifier, array $configuration)
     {
         parent::initialize($linkBrowser, $identifier, $configuration);
+
+	    // Will be removed
         $this->configuration = $configuration;
         $this->configKey = GeneralUtility::_GP('config_key');
         $this->searchString = GeneralUtility::_GP('search_field');
@@ -69,29 +73,53 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
     public function canHandleLink(array $linkParts)
     {
 
-        if (!$linkParts['url']) {
-            return false;
-        }
+	    // check first if old link style (recordlink:configkey:uid)
+	    if (isset($linkParts['url']) && !is_array($linkParts['url'])) {
+		    list($handler, $configKey, $uid) = explode(':', $linkParts['url']);
+		    if ($handler != 'recordlink') {
+			    return false;
+		    }
+		    $linkParts['url'] = array();
+		    $linkParts['url']['identifier'] = $configKey;
+		    $linkParts['url']['uid'] = $uid;
+	    }
 
-        list($handler, $configKey, $uid) = explode(':', $linkParts['url']);
+	    if (!$linkParts['url'] || !isset($linkParts['url']['identifier'])) {
+		    return false;
+	    }
 
-        if ($handler != 'record') {
-            return false;
-        }
+	    $this->configKey = $linkParts['url']['identifier'];
+	    if (!isset($this->configuration[$this->configKey.'.'])) {
+		    return false;
+	    }
+
+	    $data = $linkParts['url'];
 
 
-        if (isset($this->configuration[$configKey . '.']['table'])) {
-            $table = $this->configuration[$configKey.'.']['table'];
-        }
+	    // Get the related record
+	    $table = $this->configuration[$this->configKey.'.']['table'];
 
-        $this->linkParts = $linkParts;
-        $this->linkParts['act'] = 'record';
-        $this->linkParts['info'] = $this->configuration[$configKey.'.']['label'];
-        $this->linkParts['configKey'] = $configKey;
-        $this->linkParts['recordTable'] = $table;
-        $this->linkParts['recordUid'] = $uid;
 
-        return true;
+	    $record = BackendUtility::getRecord($table, $data['uid']);
+	    if ($record === null) {
+		    $linkParts['title'] = $this->getLanguageService()->getLL('recordNotFound');
+	    } else {
+		    $linkParts['tableName'] = $this->getLanguageService()->sL($GLOBALS['TCA'][$table]['ctrl']['title']);
+		    $linkParts['pid'] = (int)$record['pid'];
+		    $linkParts['title'] = $linkParts['title'] ?: BackendUtility::getRecordTitle($table, $record);
+	    }
+	    $linkParts['url']['type'] = $linkParts['type'];
+
+	    // This will be removed
+	    $linkParts['act'] = 'recordlink';
+	    $linkParts['info'] = $this->configuration[$this->configKey.'.']['label'];
+	    $linkParts['configKey'] = $this->configKey;
+	    $linkParts['recordTable'] = $table;
+	    $linkParts['recordUid'] = $uid;
+
+	    $this->linkParts = $linkParts;
+
+	    return true;
     }
 
     /**
@@ -123,20 +151,36 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
     {
         GeneralUtility::makeInstance(PageRenderer::class)->loadRequireJsModule('TYPO3/CMS/Recordlink/RecordLinkHandler');
 
-        $recordselector = $this->getRecordSelector();
-        $recordlist = $this->getRecordList();
-        $content = '';
-        $content .= '
+	    $content = '
+			<div class="element-browser-panel element-browser-main">
+				<div class="element-browser-main-content">
+					<div class="element-browser-body">
+						<form action="" id="lrecordselector" class="form-horizontal">
+							<div class="form-group form-group-sm">
+								<label class="col-xs-4 control-label">' . $GLOBALS['LANG']->sL('LLL:EXT:recordlink/Resources/Private/Language/locallang_be.xlf:select_linktype') . '</label>
+								<div class="col-xs-8">' . $this->getRecordSelector() . '</div>
+							</div>
+						</form>
+						' . $this->getRecordList() . '
+					</div>
+				</div>
+			</div>
+	    ';
+
+	    // Non LTS version untested
+	    if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 8000000) {
+		    $content = '
 
 				<!--
 					Wrapper table for record Selector:
 				-->
 						<table border="0" cellpadding="0" cellspacing="0" id="typo3-EBrecords">
 							<tr>
-								<td class="c-wCell" valign="top">' . $recordselector . $recordlist . '</td>
+								<td class="c-wCell" valign="top">' . $content . '</td>
 							</tr>
 						</table>
 						';
+	    }
 
         return $content;
 
@@ -147,15 +191,24 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
      */
     public function getBodyTagAttributes()
     {
-        if (empty($this->linkParts)) {
-            return [];
+
+	    $attributes = [];
+
+	    // Non LTS version untested
+	    if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 8000000) {
+		    $configKey = $this->linkParts['configKey'];
+		    $uid = $this->linkParts['recordUid'];
+		    if (!empty($this->linkParts)) {
+			    $attributes['data-current-link'] = 'recordlink:' . $configKey . ':' . $uid;
+		    }
+	    } else {
+		    if (!empty($this->linkParts)) {
+			    $attributes['data-current-link'] = GeneralUtility::makeInstance(LinkService::class)->asString($this->linkParts['url']);
+		    }
         }
 
-	    $configKey = $this->linkParts['configKey'];
-        $uid = $this->linkParts['recordUid'];
-        return [
-            'data-current-link' => empty($this->linkParts) ? '' : 'record:' . $configKey . ':' . $uid
-        ];
+	    return $attributes;
+
     }
 
     /**
@@ -165,9 +218,17 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
      */
     public function getUrlParameters(array $values)
     {
-        $parameters = [
-        ];
-        return array_merge($this->linkBrowser->getUrlParameters($values), $parameters);
+	    $pid = isset($values['pid']) ? (int)$values['pid'] : $this->expandPage;
+	    $parameters = [
+		    'expandPage' => $pid,
+		    'config_key' => $this->configKey
+	    ];
+
+	    return array_merge(
+		    $this->linkBrowser->getUrlParameters($values),
+		    ['P' => $this->linkBrowser->getParameters()],
+		    $parameters
+	    );
     }
 
     /**
@@ -177,6 +238,7 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
      */
     public function isCurrentlySelectedItem(array $values)
     {
+	    // Will be removed
 	    return false;
     }
 
@@ -187,6 +249,7 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
      */
     public function getScriptUrl()
     {
+	    // Will be removed
         return $this->linkBrowser->getScriptUrl();
     }
 
@@ -195,27 +258,22 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
     // *********
 
     protected function getRecordSelector() {
-        $out = '';
-        $out .= '<h3>'
-            . $GLOBALS['LANG']->sL('LLL:EXT:recordlink/Resources/Private/Language/locallang_be.xlf:select_linktype')
-            . ':</h3>';
-        $out .= '<div class="form-group">';
-        $onChange = 'onchange="jumpToUrl(' . GeneralUtility::quoteJSvalue('?act=record&config_key=') . ' + this.value); return false;"';
-        $out .= '<select class="form-control" ' . $onChange . ' >';
-        $out .= '<option value=""></option>';
-	    $configKey = (!empty($this->configKey))
-        	? $this->configKey
-	        : $this->linkParts['configKey'];
-        foreach ($this->configuration as $key => $config) {
-            $key = substr($key, 0, -1);
-            if($key==$configKey) {
-                $out .= '<option value="'.$key.'" selected="selected">'.$config['label'].'</option>';
-            } else {
-                $out .= '<option value="'.$key.'">'.$config['label'].'</option>';
-            }
-        }
-        $out .= '</select>';
-        $out .= '</div>';
+	    $out = '';
+	    $onChange = 'onchange="jumpToUrl(' . GeneralUtility::quoteJSvalue('?act=recordlink&config_key=') . ' + this.value); return false;"';
+	    $out .= '<select class="form-control" ' . $onChange . ' >';
+	    $out .= '<option value=""></option>';
+	    foreach ($this->configuration as $key => $config) {
+		    if(substr($key, -1, 1) == '.') {
+			    $key = substr($key, 0, -1);
+			    $label = (isset($config['label'])) ? $config['label'] : '';
+			    if($key==$this->configKey) {
+				    $out .= '<option value="'.$key.'" selected="selected">'.$label.'</option>';
+			    } elseif (!empty($key)) {
+				    $out .= '<option value="'.$key.'">'.$label.'</option>';
+			    }
+		    }
+	    }
+	    $out .= '</select>';
         return $out;
     }
 

--- a/Classes/LinkHandler/RecordLinkHandler.php
+++ b/Classes/LinkHandler/RecordLinkHandler.php
@@ -82,6 +82,12 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
 		    $linkParts['url'] = array();
 		    $linkParts['url']['identifier'] = $configKey;
 		    $linkParts['url']['uid'] = $uid;
+	    } elseif(is_array($linkParts['url']) && isset($linkParts['url']['url']) && isset($linkParts['type']) && $linkParts['type']=='recordlink') {
+	        // T3 8 LTS
+		    list($configKey, $uid) = explode(':', $linkParts['url']['url']);
+			unset($linkParts['url']['url']);
+		    $linkParts['url']['identifier'] = $configKey;
+		    $linkParts['url']['uid'] = $uid;
 	    }
 
 	    if (!$linkParts['url'] || !isset($linkParts['url']['identifier'])) {
@@ -150,7 +156,6 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
     public function render(ServerRequestInterface $request)
     {
         GeneralUtility::makeInstance(PageRenderer::class)->loadRequireJsModule('TYPO3/CMS/Recordlink/RecordLinkHandler');
-
 	    $content = '
 			<div class="element-browser-panel element-browser-main">
 				<div class="element-browser-main-content">
@@ -194,18 +199,11 @@ class RecordLinkHandler extends AbstractLinkHandler implements LinkHandlerInterf
 
 	    $attributes = [];
 
-	    // Non LTS version untested
-	    if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 8000000) {
-		    $configKey = $this->linkParts['configKey'];
-		    $uid = $this->linkParts['recordUid'];
-		    if (!empty($this->linkParts)) {
-			    $attributes['data-current-link'] = 'recordlink:' . $configKey . ':' . $uid;
-		    }
-	    } else {
-		    if (!empty($this->linkParts)) {
-			    $attributes['data-current-link'] = GeneralUtility::makeInstance(LinkService::class)->asString($this->linkParts['url']);
-		    }
-        }
+	    $configKey = $this->linkParts['configKey'];
+	    $uid = $this->linkParts['recordUid'];
+	    if (!empty($this->linkParts)) {
+		    $attributes['data-current-link'] = 'recordlink:' . $configKey . ':' . $uid;
+	    }
 
 	    return $attributes;
 

--- a/Classes/RecordList/RecordRecordList.php
+++ b/Classes/RecordList/RecordRecordList.php
@@ -165,7 +165,7 @@ class RecordRecordList extends DatabaseRecordList
 		return $this->addElement(1, '', $data);
 	}
 
-	public function getSearchBox() {
+	public function getSearchBox($formFields = true) {
 
 		$formElements = array('<form action="' . htmlspecialchars($this->getSearchURL()) . '" method="post" style="padding:0;">', '</form>');
 

--- a/Classes/RecordList/RecordRecordList.php
+++ b/Classes/RecordList/RecordRecordList.php
@@ -191,7 +191,7 @@ class RecordRecordList extends DatabaseRecordList
 
 	public function getBrowseURL() {
 		if (!isset($this->browseURL)) {
-			$this->browseURL = $this->listURL() . '&act=record&config_key='.$this->configKey;
+			$this->browseURL = $this->listURL() . '&act=recordlink&config_key='.$this->configKey;
 		}
 		return $this->browseURL;
 	}

--- a/Configuration/PageTS/recordlink.txt
+++ b/Configuration/PageTS/recordlink.txt
@@ -1,7 +1,7 @@
 
 # TS Config Recordlink Example
 
-TCEMAIN.linkHandler.record.configuration {
+TCEMAIN.linkHandler.recordlink.configuration {
 	category {
 		 label = Categories
 		 table = sys_category

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,5 +1,5 @@
 
-# TS Config Recordlink Example
+# TypoScript Recordlink Example
 
 plugin.tx_recordlink.category {
 	table = sys_category

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Recordlink
+
+### Important notice for version 1.3.0
+This version is a bridge for upgrade from TYPO3 7.6 to 8 LTS
+
+- Install this version before upgrade your CMS 
+- Perform query manualy. You can find some example running update script
+- Upgrade TYPO3 to 8 LTS 
+- Update Recordlink to next version 2.0.0 
+
+Query for update link fields: 
+- UPDATE [table] SET [field] = REPLACE([field], 'record:[key]', 'recordlink:[key]') WHERE 1=1
+
+Query for update rte fields: 
+- UPDATE [table] SET [field] = REPLACE([field], '<link record:[key]', '<link recordlink:[key]') WHERE 1=1
+
+Example Query for tt_content and sys_file_reference for example key "category": 
+- UPDATE tt_content SET header_link = REPLACE(header_link, 'record:category', 'recordlink:category') WHERE 1=1;
+- UPDATE tt_content SET bodytext = REPLACE(bodytext, '<link record:category', '<link recordlink:category') WHERE 1=1;
+- UPDATE sys_file_reference SET link = REPLACE(link, 'record:category', 'recordlink:category') WHERE 1=1;

--- a/Resources/Public/JavaScript/RecordLinkHandler.js
+++ b/Resources/Public/JavaScript/RecordLinkHandler.js
@@ -37,7 +37,7 @@ define(['jquery', 'TYPO3/CMS/Recordlist/LinkBrowser'], function($, LinkBrowser) 
 		var config = $(this).data('config');
 		var uid = $(this).data('uid');
 
-		LinkBrowser.finalizeFunction('record:' + config + ':' + uid);
+		LinkBrowser.finalizeFunction('recordlink:' + config + ':' + uid);
 	};
 
 	/**

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,0 +1,67 @@
+<?php
+namespace Intera\Recordlink;
+
+
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
+use TYPO3\CMS\Install\Service\SqlSchemaMigrationService;
+
+/**
+ * Class for updating the db
+ */
+class ext_update
+{
+	/**
+	 * @var string Name of the extension this controller belongs to
+	 */
+	protected $extensionName = 'Recordlink';
+
+	/**
+	 * @var \TYPO3\CMS\Extbase\Object\ObjectManager Extbase Object Manager
+	 */
+	protected $objectManager;
+	
+	/**
+	 * @var \TYPO3\CMS\Extensionmanager\Utility\InstallUtility Extension Manager Install Tool
+	 */
+	protected $installTool;
+
+	/**
+	 * Main function, returning the HTML content
+	 *
+	 * @return string HTML
+	 */
+	public function main()
+	{
+		$content = '';
+		$content .= '<h2>';
+		$content .= 'Please perform query manualy before upgrade to TYPO3 8 LTS. Follow examples:';
+		$content .= '</h2>';
+		$content .= '<p>'
+			. 'Query for update link fields: ' . '<br>'
+			. 'UPDATE [table] SET [field] = REPLACE([field], \'record:[key]\',  \'recordlink:[key]\') WHERE 1=1'
+			. '</p>';
+		$content .= '<p>'
+			. 'Query for update rte fields: ' . '<br>'
+			. 'UPDATE [table] SET [field] = REPLACE([field], \'<link record:[key]\',  \'<link recordlink:[key]\') WHERE 1=1'
+			. '</p>';
+
+		$content .= '<p>'
+			. 'Example Query for tt_content and sys_file_reference for example key "category": ' . '<br>'
+			. 'UPDATE tt_content SET header_link = REPLACE(header_link, \'record:category\', \'recordlink:category\') WHERE 1=1;' .'<br>'
+			. 'UPDATE tt_content SET bodytext = REPLACE(bodytext, \'&lt;link record:category\', \'&lt;link recordlink:category\') WHERE 1=1;' .'<br>'
+			. 'UPDATE sys_file_reference SET link = REPLACE(link, \'record:category\', \'recordlink:category\') WHERE 1=1;'
+			. '</p>';
+
+		return $content;
+	}
+
+
+	public function access()
+	{
+		return true;
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "GPL-2.0",
   "version": "1.2.0",
   "require": {
-    "typo3/cms": ">=7.6.0 <7.6.99"
+    "typo3/cms": ">=7.6.0 <8.7.99"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "description": "Record Link",
   "type": "typo3-cms-extension",
   "license": "GPL-2.0",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "require": {
     "typo3/cms": ">=7.6.0 <8.7.99"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' => 
 		array (
-			'typo3' => '7.6.0-7.6.99',
+			'typo3' => '7.6.0-8.7.99',
 		),
 		'conflicts' => 
 		array (

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,29 +11,29 @@
  ***************************************************************/
 
 $EM_CONF[$_EXTKEY] = array (
-	'title' => 'Record Link',
-	'description' => 'Add custom link to records like system category or news',
-	'category' => 'plugin',
-	'version' => '1.2.0',
-	'state' => 'beta',
-	'uploadfolder' => false,
-	'createDirs' => '',
-	'clearcacheonload' => false,
-	'author' => 'Cristian Buja',
-	'author_email' => 'cristian.buja@intera.it',
-	'author_company' => NULL,
-	'constraints' => 
-	array (
-		'depends' => 
-		array (
-			'typo3' => '7.6.0-8.7.99',
-		),
-		'conflicts' => 
-		array (
-		),
-		'suggests' => 
-		array (
-		),
-	),
+  'title' => 'Record Link',
+  'description' => 'Add custom link to records like system category or news',
+  'category' => 'plugin',
+  'version' => '1.3.0',
+  'state' => 'beta',
+  'uploadfolder' => false,
+  'createDirs' => '',
+  'clearcacheonload' => false,
+  'author' => 'Cristian Buja',
+  'author_email' => 'cristian.buja@intera.it',
+  'author_company' => NULL,
+  'constraints' =>
+  array (
+    'depends' =>
+    array (
+      'typo3' => '7.6.0-8.7.99',
+    ),
+    'conflicts' =>
+    array (
+    ),
+    'suggests' =>
+    array (
+    ),
+  ),
 );
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,21 @@ if (!defined ('TYPO3_MODE')) {
   die ('Access denied.');
 }
 
-// Register linkhandler for "record"
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['record']
-    = 'Intera\Recordlink\Hooks\LinkHandler';
+
+// Backend Form
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['linkHandler']['recordlink']
+	= 'Intera\Recordlink\Hooks\FormEngineLinkHandler';
+
+// Frontend
+$GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['recordlink']
+	= 'Intera\Recordlink\Hooks\RecordLinkBuilder';
+
+
+
+// NOTE: Will be removed when  7.6 compatibility will be dropped
+
+// Frontend
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['recordlink']
+	= 'Intera\Recordlink\Hooks\LinkHandler';
+
+

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,8 +6,8 @@ if (TYPO3_MODE === 'BE') {
     // register record link handlers
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('
 		TCEMAIN.linkHandler {
-			record {
-				handler = Intera\\Recordlink\\LinkHandler\\RecordLinkHandler
+			recordlink {
+				handler = Intera\Recordlink\LinkHandler\RecordLinkHandler
 				label = LLL:EXT:recordlink/Resources/Private/Language/locallang_be.xlf:record
 				scanAfter = page
 				configuration {


### PR DESCRIPTION
Release 1.3.0

This version is a bridge for upgrade from TYPO3 7.6 to 8 LTS

- Install this version before upgrade your CMS 
- Perform query manualy. You can find some example running update script
- Upgrade TYPO3 to 8 LTS 
- Update Recordlink to next version 2.0.0 